### PR TITLE
feature/fix-docker => Add .dockerignore file. Exposes port 3001.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.git
+.gitignore
+.env

--- a/dockerfile
+++ b/dockerfile
@@ -15,7 +15,7 @@ COPY . .
 RUN npm run build
 
 # Expose the port NestJS will run on
-EXPOSE 3000
+EXPOSE 3001
 
 # Start the application
 CMD ["npm", "run", "start:prod"]

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "build:image" : "docker build -t crypto-track-api:ver1 .",
-    "start:temp:image": "docker run --rm --name crypto-api -p 3000:3000 crypto-track-api:ver1"
+    "start:temp:image": "docker run --rm --name crypto-api -p 3001:3001 crypto-track-api:ver1"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,6 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(process.env.PORT ?? 3000);
+  await app.listen(process.env.PORT ?? 3001);
 }
 bootstrap();


### PR DESCRIPTION
**Docker Fix: Backend Port Reconfiguration + .dockerignore**
**Summary**
This PR adjusts the backend service to run on port 3001 instead of the default 3000, resolving a conflict with the frontend Docker container. It also includes a .dockerignore file to optimize build performance and reduce image size.

**Changes Made**
- Updated main.ts to default to PORT 3001
- Modified package.json Docker script to use port 3001
- Adjusted Dockerfile to expose port 3001
- Added .dockerignore file to exclude unnecessary files:

```
node_modules
npm-debug.log
Dockerfile
.dockerignore
.git
.gitignore
.env
```
**Reference**
Followed the setup recommendations from 📄 Dockerizing Vite + React Guide

**Why This Matters**
- Prevents port collision with the frontend container (which runs on 3000)
- Improves Docker build efficiency and cleanliness
- Ensures smoother local development and better container isolation