### PR TITLE
feature/query_page => Enable pagination to GET crypto/portfolio/all?offset={}&limit={}

### DIFF
--- a/src/crypto/portfolio/dto/pagination.dto.ts
+++ b/src/crypto/portfolio/dto/pagination.dto.ts
@@ -1,0 +1,19 @@
+import { Type } from 'class-transformer';
+import { IsNumber, IsOptional, IsPositive, Min } from 'class-validator';
+
+export class PaginationDto {
+
+  //@Type(() => Number) tells NestJS to convert the string query param to a number before validation. Without this, IsPositive and IsNumber will fail
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsPositive()
+  @IsNumber()
+  limit?: number; // Number of items per page
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  offset?: number; // Starting offset
+}

--- a/src/crypto/portfolio/portfolio.controller.ts
+++ b/src/crypto/portfolio/portfolio.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query, UseGuards, UsePipes, ValidationPipe } from '@nestjs/common';
 import { AuthGuard } from '@src/guards/auth.guard';
 import { PortfolioDTO } from './dto/portfolio.dto';
 import { Serialize } from '@src/interceptors/serialize.interceptor';
@@ -10,6 +10,7 @@ import { PortfolioService } from './portfolio.service';
 import { UpdatePortfolioDto } from './dto/update-portfolio.dto';
 import { CheckPortfolioGuard } from './guards/check-portfolio.guard';
 import { UpdateResult } from 'typeorm';
+import { PaginationDto } from './dto/pagination.dto';
 
 @Controller('crypto/portfolio')
 @UseGuards(AuthGuard)
@@ -21,8 +22,8 @@ export class PortfolioController {
 
   @Get('/all')
   @Serialize(PortfolioDTO)
-  async findAll(@CurrentUser() user: User){
-    return await this.portfolioService.findAll(user.id);
+  async findAll(@Query() pagination: PaginationDto,@CurrentUser() user: User){
+    return await this.portfolioService.findAll(user.id, pagination);
   }
 
   @Post()

--- a/src/crypto/portfolio/portfolio.service.spec.ts
+++ b/src/crypto/portfolio/portfolio.service.spec.ts
@@ -7,6 +7,7 @@ import { CreatePortfolioDto } from './dto/create-portfolio.dto';
 import { UpdatePortfolioDto } from './dto/update-portfolio.dto';
 import { CreateCryptoDto } from '@src/crypto/dto/create-crypto.dto';
 import { Repository } from 'typeorm';
+import { PaginationDto } from './dto/pagination.dto';
 
 const { spyOn, resetAllMocks, fn } = jest;
 
@@ -56,6 +57,32 @@ describe('PortfolioService', () => {
       expect(await service.findOne(1)).toEqual(mockPortfolio);
     });
   });
+
+
+  describe('findAll()', () => {
+    it('returns null if no id provided', async () => {
+      expect(await service.findAll(undefined,undefined)).toBeNull();
+    });
+
+    it('returns portfolio when found', async () => {
+      const pagination: PaginationDto = {
+        limit: 10,
+        offset: 0
+      }
+
+      const mockPortfolio = { id: 1, Amount: 10, PurchasePrice: 999, DateOfPurchase: new Date('2025-07-29T10:00:00.000Z') };
+      //@ts-ignore
+      spyOn(fakePortfolioRepo, 'find').mockResolvedValue(mockPortfolio);
+      expect(await service.findAll(1,pagination)).toEqual(mockPortfolio);
+
+      //@ts-ignore
+      spyOn(fakePortfolioRepo, 'find').mockResolvedValue(mockPortfolio);
+      expect(await service.findAll(1,undefined)).toEqual(mockPortfolio);
+    });
+
+
+  });
+
 
   describe('create()', () => {
     it('creates portfolio from DTO and user', async () => {

--- a/src/crypto/portfolio/portfolio.service.ts
+++ b/src/crypto/portfolio/portfolio.service.ts
@@ -5,6 +5,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { User } from '@user/entities/user.entity';
 import { CreatePortfolioDto } from '@portfolio/dto/create-portfolio.dto';
 import { UpdatePortfolioDto } from './dto/update-portfolio.dto';
+import { PaginationDto } from './dto/pagination.dto';
 
 
 @Injectable()
@@ -35,19 +36,22 @@ export class PortfolioService {
       relations:['crypto','user']});
   }
 
-  async findAll(userId: number): Promise<Portfolio[]>{
+  async findAll(userId: number, pagination?: PaginationDto): Promise<Portfolio[]>{
     if(!userId){
       return null;
     }
+    const { limit = 10, offset = 0 } = pagination || {};
 
     return await this.portfolioRepo.find({
       relations: ['crypto'],
       where: { user : { id:userId }},
+      skip: offset,
+      take: limit,
     })
   }
 
   async create(createPortfolioDto: CreatePortfolioDto, user: User) {
-    const createdHistory = await this.portfolioRepo.create({
+    const createdHistory = this.portfolioRepo.create({
       dateOfPurchase: createPortfolioDto.dateOfPurchase,
       purchasePrice: createPortfolioDto.purchasePrice,
       amount: createPortfolioDto.amount,

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,10 +7,12 @@ async function bootstrap() {
 
   app.enableCors({
     origin: 'http://localhost:8080', // allow your frontend origin
-    methods: 'GET,POST,PUT,DELETE', // specify allowed methods
+    methods: 'GET,POST,PUT,DELETE,PATCH', // specify allowed methods
     credentials: true, // if using cookies or auth headers
   });
-  app.useGlobalPipes(new ValidationPipe());
+
+  //Use{ transform: true } to ensure this dto Query() transformation always happens
+  app.useGlobalPipes(new ValidationPipe({ transform: true }));
 
   await app.listen(process.env.PORT ?? 3001);
 }


### PR DESCRIPTION
### ✅ Pull Request Description

This PR introduces query-based pagination support for `GET /crypto/portfolio/all`.

- Added `PaginationDto` in `crypto/portfolio/dto/pagination.dto` to handle optional query parameters `limit` and `offset`.
- Updated `PortfolioController` (`crypto/portfolio/portfolio.controller.ts`) to consume `PaginationDto` via `@Query()`.
- Enhanced `PortfolioService.findAll()` (`crypto/portfolio/portfolio.service.ts`) to apply pagination via `take` and `skip` using TypeORM.
- Added unit test for `PortfolioService.findAll()` to validate pagination behavior.
- Pagination can be triggered with or without query parameters, e.g. `localhost:3001/crypto/portfolio/all?limit=2&offset=2`.
